### PR TITLE
fix: which -s is an illegal option

### DIFF
--- a/src/bash-rollup.sh
+++ b/src/bash-rollup.sh
@@ -178,7 +178,7 @@ if [[ -n "${SOURCE_ONLY}" ]]; then
     fi
   done < <(cat "${MAIN_FILE}") > "${OUT_FILE}" # Note we replace existing file if any.
 else # process for reals
-  if ! which -s perl; then
+  if [[ -z "$(which perl)" ]]; then
     echoerrandexit "Perl is required."
     exit 10
   fi


### PR DESCRIPTION
When I try to execute your program on WSL2 (Ubuntu 20.04), I get the following error:
```
Illegal option -s
Usage: /usr/bin/which [-a] args
```

I replaced it with:
```bash
if [[ -z "$(which perl)" ]]; then
#...
```